### PR TITLE
Ensure .mp4 is video/mp4

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -3,7 +3,8 @@ const db = require('mime-db')
 const override = {
   js: { type: 'application/javascript', charset: 'utf-8' },
   cjs: { type: 'application/javascript', charset: 'utf-8' },
-  mjs: { type: 'application/javascript', charset: 'utf-8' }
+  mjs: { type: 'application/javascript', charset: 'utf-8' },
+  mp4: { type: 'video/mp4' }
 }
 
 let s = 'const m = {\n'

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ const m = {
   mods: { type: 'application/mods+xml', charset: null },
   m21: { type: 'application/mp21', charset: null },
   mp21: null,
-  mp4: { type: 'application/mp4', charset: null },
+  mp4: { type: 'video/mp4', charset: null },
   mpg4: null,
   mp4s: null,
   m4p: null,

--- a/test.js
+++ b/test.js
@@ -33,6 +33,8 @@ test('without charset', function (t) {
   t.is(mimetype, 'application/json')
 })
 
+// js
+
 test('.js is application/javascript', function (t) {
   const name = 'sample.js'
 
@@ -55,4 +57,122 @@ test('.cjs is application/javascript', function (t) {
   const mimetype = getMimeType(name)
 
   t.is(mimetype, 'application/javascript; charset=utf-8')
+})
+
+// images
+
+test('.jpg is image/jpeg', function (t) {
+  const name = 'sample.jpg'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/jpeg')
+})
+
+test('.jpeg is image/jpeg', function (t) {
+  const name = 'sample.jpeg'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/jpeg')
+})
+
+test('.png is image/png', function (t) {
+  const name = 'sample.png'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/png')
+})
+
+test('.tif is image/tiff', function (t) {
+  const name = 'sample.tif'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/tiff')
+})
+
+test('.tiff is image/tiff', function (t) {
+  const name = 'sample.tiff'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/tiff')
+})
+
+test('.heic is image/heic', function (t) {
+  const name = 'sample.heic'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/heic')
+})
+
+test('.heif is image/heif', function (t) {
+  const name = 'sample.heif'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/heif')
+})
+
+test('.webp is image/webp', function (t) {
+  const name = 'sample.webp'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/webp')
+})
+
+test('.gif is image/gif', function (t) {
+  const name = 'sample.gif'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'image/gif')
+})
+
+// video
+
+test('.mp4 is video/mp4', function (t) {
+  const name = 'sample.mp4'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'video/mp4')
+})
+
+test('.mov is video/quicktime', function (t) {
+  const name = 'sample.mov'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'video/quicktime')
+})
+
+test('.webm is video/webm', function (t) {
+  const name = 'sample.webm'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'video/webm')
+})
+
+// audio
+
+test('.mp3 is audio/mp3', function (t) {
+  const name = 'sample.mp3'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'audio/mp3')
+})
+
+test('.wav is audio/wav', function (t) {
+  const name = 'sample.wav'
+
+  const mimetype = getMimeType(name)
+
+  t.is(mimetype, 'audio/wav')
 })


### PR DESCRIPTION
.mp4 was overwritten to `application/mp4` with the latest generation, this ensures it will be always `video/mp4` as it's the most common mimetype for the extension. Also added tests for some common media types.